### PR TITLE
Fixed parameters string format error

### DIFF
--- a/src/create-ffmpeg-shell-commands/create-ffmpeg-shell-commands.ts
+++ b/src/create-ffmpeg-shell-commands/create-ffmpeg-shell-commands.ts
@@ -63,7 +63,7 @@ function createFFmpegShellCommand(
     result.push(`-to ${ffmpegFlags.to}`)
   }
   // `-ss` and `-t` must come before the `-i` flag
-  result.push(`-i '${ffmpegFlags.i}'`)
+  result.push(`-i "${ffmpegFlags.i}"`)
   if (ffmpegFlags.an === true) {
     result.push(`-an`)
   }
@@ -86,5 +86,5 @@ function createFFmpegShellCommand(
   const outputDirectory = path.dirname(outputFile)
   return `mkdir -p '${outputDirectory}' && ${ffmpegBinaryPath} ${result.join(
     ' '
-  )} -y '${outputFile}'`
+  )} -y "${outputFile}"`
 }


### PR DESCRIPTION
Input paths containing an apostrophe would fail due to a string formatting error.
This fixes that by setting the final ffmpeg CLI command to use double quotes rather than single quotes